### PR TITLE
GenPinoutSVG.py: Fix compatibility issue with py3-wand

### DIFF
--- a/GenPinoutSVG.py
+++ b/GenPinoutSVG.py
@@ -224,9 +224,10 @@ def writeIcon(params):
       return False
 
     # Then get raw PNG data and encode DIRECTLY into the SVG file.
-    image_data = img.make_blob()
-    encoded = base64.b64encode(image_data).decode()
-    pngdata = 'data:image/svg+xml;base64,{}'.format(encoded)
+    with open(imgfile, "rb") as imgfile:
+      image_data = imgfile.read()
+      encoded = base64.b64encode(image_data).decode()
+      pngdata = 'data:image/svg+xml;base64,{}'.format(encoded)
 
     W = round(get_size(W,img.width))
     H = round(get_size(H,img.height))


### PR DESCRIPTION
Image().make_blob() no longer works with a current py3-wand on SVG files. Instead, the reading the SVG bytes directly from file still works.

Interestingly, this results in a slightly smaller generated SVG file for me. The file appears to look identical, though.